### PR TITLE
Fixing warnings in puppet 3.2.1

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -2,7 +2,7 @@
 # See the sshd(8) manpage for details
 
 # What ports, IPs and protocols we listen for
-Port <%= port %>
+Port <%= @port %>
 # Use these options to restrict which interfaces/protocols sshd will bind to
 #ListenAddress ::
 #ListenAddress 0.0.0.0
@@ -75,6 +75,6 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 
 UsePAM yes
 
-<% if allowed_users.any? %>
-AllowUsers <%= allowed_users.join(" ") %>
+<% if @allowed_users.any? %>
+AllowUsers <%= @allowed_users.join(" ") %>
 <% end %>


### PR DESCRIPTION
Puppet 3.2.1 is complaining about the sshd_config.erb file as follows:

Variable access via 'port' is deprecated. Use '@port' instead. template[/etc/puppet/modules/ssh/templates/sshd_config.erb]:5

This patch eliminates the warning (tested against Puppet 3.2.1 only).
