### PR TITLE
Make it possible not to manage the service.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,6 +7,7 @@ class ssh::server(
   $subsystem_sftp='/usr/lib/openssh/sftp-server',
   $permit_root_login='no',
   $host_keys=$ssh::params::host_keys,
+  $manage_service=true
 ) inherits ssh::params {
   package { 'openssh-server':
     ensure => present,
@@ -20,13 +21,15 @@ class ssh::server(
     mode  => '0644'
   }
 
-  service { 'ssh':
-    ensure    => running,
-    name      => $ssh::params::service_name,
-    enable    => true,
-    hasstatus => true,
-    subscribe => [Package['openssh-server'], File['/etc/ssh/sshd_config']],
-    require   => File['/etc/ssh/sshd_config'],
+  if $manage_service {
+    service { 'ssh':
+      ensure    => running,
+      name      => $ssh::params::service_name,
+      enable    => true,
+      hasstatus => true,
+      subscribe => [Package['openssh-server'], File['/etc/ssh/sshd_config']],
+      require   => File['/etc/ssh/sshd_config'],
+    }
   }
 
   if $permit_root_login == 'true' {


### PR DESCRIPTION
I want this for setting up ssh inside docker containers,
as I don't want the service touched as I'm building a container
