### PR TITLE
Add variable for UsePAM directive.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,6 +9,7 @@ class ssh::server(
   $password_authentication='no',
   $pubkey_authentication='yes',
   $subsystem_sftp='/usr/lib/openssh/sftp-server',
+  $use_pam='yes',
   $permit_root_login='no',
   $host_keys=$ssh::params::host_keys,
   $manage_service=true

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -76,7 +76,7 @@ AcceptEnv LANG LC_*
 
 #Subsystem sftp /usr/lib/openssh/sftp-server
 Subsystem sftp <%= @subsystem_sftp %>
-UsePAM yes
+UsePAM <%= @use_pam %>
 
 <% if @allowed_users.any? %>
 AllowUsers <%= @allowed_users.join(" ") %>


### PR DESCRIPTION
In order to get SSH working properly from within a docker container I [had to disable UsePAM](https://gist.github.com/gasi/5691565).  This pull request makes that option configurable from the `ssh::server` class.
