### PR TITLE
Make sure @ciphers isn't an empty array

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -80,7 +80,7 @@ ClientAliveInterval <%= @client_alive_interval %>
 ClientAliveCountMax <%= @client_alive_count_max %>
 <% end -%>
 
-<% if @ciphers -%>
+<% if @ciphers.any? -%>
 Ciphers <%= @ciphers.join(",") %>
 <% end -%>
 


### PR DESCRIPTION
Make this module not break sshd with the default ciphers list

I just upgraded to the most recent version of this module and ran puppet, expecting no change.  What I got instead was a small change to /etc/ssh/sshd_config that kept sshd from starting :(

The problem is in templates/sshd_config.erb, lines 83-85:

``` erb
<% if @ciphers -%>
Ciphers <%= @ciphers.join(",") %>
<% end -%>
```

manifests/server.pp line 18 is: 

``` puppet
$ciphers=[],
```

Which exists but is empty :(

I just changed the check to make sure there's something in that array.

An equally-reasonable fix would be to default `$ciphers` to `undef` instead.  I'm sure there's some style guide entry somewhere that says, but I don't know.
