### PR TITLE
Extra parameters

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@ class ssh::params {
   $accept_env                      = 'LANG LC_*'
   $allowed_users                   = []
   $allowed_groups                  = []
-  $authorized_keys_file            = '%h/.ssh/authorized_keys'
+  $authorized_keys_file            = ['%h/.ssh/authorized_keys']
   $banner_manage                   = true
   $banner_template                 = 'ssh/issue.erb'
   $client_alive_interval           = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class ssh::params {
   $accept_env                      = 'LANG LC_*'
   $allowed_users                   = []
   $allowed_groups                  = []
+  $authorized_keys_file            = '%h/.ssh/authorized_keys'
   $banner_manage                   = true
   $banner_template                 = 'ssh/issue.erb'
   $client_alive_interval           = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class ssh::params {
   $password_authentication         = 'no'
   $permit_root_login               = 'no'
   $permit_tunnel                   = 'no'
+  $gateway_ports                   = 'no'
   $port                            = '22'
   $print_motd                      = 'no'
   $pubkey_authentication           = 'yes'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,6 +17,7 @@ class ssh::server (
   $password_authentication_users  = $::ssh::params::password_authentication_users,
   $permit_root_login              = $::ssh::params::permit_root_login,
   $permit_tunnel                  = $::ssh::params::permit_tunnel,
+  $gateway_ports                  = $::ssh::params::gateway_ports,
   $print_motd                     = $::ssh::params::print_motd,
   $pubkey_authentication          = $::ssh::params::pubkey_authentication,
   $subsystem_sftp                 = $::ssh::params::subsystem_sftp,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -2,6 +2,7 @@ class ssh::server (
   $accept_env                     = $::ssh::params::accept_env,
   $allowed_users                  = $::ssh::params::allowed_users,
   $allowed_groups                 = $::ssh::params::allowed_groups,
+  $authorized_keys_file           = $::ssh::params::authorized_keys_file,
   $banner_file                    = $::ssh::params::banner_file,
   $banner_manage                  = $::ssh::params::banner_manage,
   $banner_template                = $::ssh::params::banner_template,

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -46,6 +46,7 @@ describe 'ssh::server', :type => :class do
         :banner_file            => '/etc/banner.txt',
         :ciphers                => ['aes128-ctr','aes192-ctr','aes256-ctr','arcfour256','arcfour128'],
         :macs                   => ['hmac-sha1','hmac-ripemd160'],
+        :gateway_ports          => 'clientspecified',
         :client_alive_interval  => '30',
         :client_alive_count_max => '5'
       }
@@ -68,5 +69,6 @@ describe 'ssh::server', :type => :class do
     it { is_expected.to contain_file("/etc/ssh/sshd_config").with_content %r{^MACs hmac-sha1,hmac-ripemd160$} }
     it { is_expected.to contain_file("/etc/ssh/sshd_config").with_content %r{^ClientAliveInterval 30$} }
     it { is_expected.to contain_file("/etc/ssh/sshd_config").with_content %r{^ClientAliveCountMax 5$} }
+    it { is_expected.to contain_file("/etc/ssh/sshd_config").with_content %r{^GatewayPorts clientspecified$} }
   end
 end

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -116,3 +116,5 @@ Match User <%= val %>
 <% end -%>
 
 PermitTunnel <%= @permit_tunnel %>
+
+GatewayPorts <%= @gateway_ports %>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -28,7 +28,15 @@ StrictModes yes
 
 RSAAuthentication yes
 PubkeyAuthentication <%= @pubkey_authentication %>
-AuthorizedKeysFile	%h/.ssh/authorized_keys
+<%- if @authorized_keys_file.any? -%>
+<%- if @osfamily == 'RedHat' -%>
+<%# RedHat 6 has openssh-5.3, and it does not support multi AuthorizedKeysFile %>
+<%# So we take the first one%>
+AuthorizedKeysFile <%= @authorized_keys_file.flatten[0] %>
+<%- else -%>
+AuthorizedKeysFile <%= @authorized_keys_file.flatten.join(" ") %>
+<%- end -%>
+<%- end -%>
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes


### PR DESCRIPTION
1 - adding $authorized_keys_file to have more than one location for authorized_keys  
Example: 
```
authorized_keys_file => ['%h/.ssh/authorized_keys', '/etc/ssh/keys/%u_authorized_keys',] 
```
Useful to let user manage their own authorized keys, but deploy some infrastructure wide keys. 

2 - Add GatewayPorts to allow tcp port forwarding to listen on 0.0.0.0. 

3 - I ran rspec to check if code was OK; 
I wrote a spec test, but I haven't taken the time to load stdlib into the module. 
```
Unknown function str2bool [...]
```

If you need anything, just let me know. 
Thanks for sharing