### PR TITLE
Add PermitUserEnvironment

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class ssh::params {
   $password_authentication         = 'no'
   $permit_root_login               = 'no'
   $permit_tunnel                   = 'no'
+  $permit_user_environment         = 'no'
   $gateway_ports                   = 'no'
   $port                            = '22'
   $print_motd                      = 'no'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -18,6 +18,7 @@ class ssh::server (
   $password_authentication_users  = $::ssh::params::password_authentication_users,
   $permit_root_login              = $::ssh::params::permit_root_login,
   $permit_tunnel                  = $::ssh::params::permit_tunnel,
+  $permit_user_environment        = $::ssh::params::permit_user_environment,
   $gateway_ports                  = $::ssh::params::gateway_ports,
   $print_motd                     = $::ssh::params::print_motd,
   $pubkey_authentication          = $::ssh::params::pubkey_authentication,

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -126,3 +126,5 @@ Match User <%= val %>
 PermitTunnel <%= @permit_tunnel %>
 
 GatewayPorts <%= @gateway_ports %>
+
+PermitUserEnvironment <%= @permit_user_environment %>


### PR DESCRIPTION
PermitUserEnvironment allows environment variables to be set in
the authorized_keys file for a specific key.