### PR TITLE
Mitigate CVE-2016-0777, add UseRoaming no to ssh_config

### DIFF
--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -34,6 +34,7 @@ SendEnv LANG LC_*
 HashKnownHosts yes
 GSSAPIAuthentication yes
 GSSAPIDelegateCredentials no
+UseRoaming no
 
 <%- if @known_host_sssd != '' -%>
 GlobalKnownHostsFile /var/lib/sss/pubconf/known_hosts


### PR DESCRIPTION
See http://www.openssh.com/txt/release-7.1p2 or https://www.qualys.com/2016/01/14/cve-2016-0777-cve-2016-0778/openssh-cve-2016-0777-cve-2016-0778.txt for more information.