### PR TITLE
Fix template checks for undef variables

### DIFF
--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -36,7 +36,7 @@ GSSAPIAuthentication yes
 GSSAPIDelegateCredentials no
 UseRoaming no
 
-<%- if @known_host_sssd != '' -%>
+<%- if @known_host_sssd -%>
 GlobalKnownHostsFile /var/lib/sss/pubconf/known_hosts
 ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h
 <%- end -%>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -5,7 +5,7 @@ Port <%= @port %>
 # Use these options to restrict which interfaces/protocols sshd will bind to
 #ListenAddress ::
 #ListenAddress 0.0.0.0
-<%- if @address_family != '' -%>
+<%- if @address_family -%>
 AddressFamily <%= @address_family %>
 <%- end -%>
 Protocol 2
@@ -41,10 +41,10 @@ AuthorizedKeysFile <%= @authorized_keys_file.flatten.join(" ") %>
 <%- end -%>
 <%- end -%>
 
-<%- if @authorized_keys_command != '' -%>
+<%- if @authorized_keys_command -%>
 AuthorizedKeysCommand <%= @authorized_keys_command %>
 <%- end -%>
-<%- if @authorized_keys_command_user != '' -%>
+<%- if @authorized_keys_command_user -%>
 AuthorizedKeysCommandUser <%= @authorized_keys_command_user %>
 <%- end -%>
 


### PR DESCRIPTION
At the moment when you simply have a manifest like this:

```
    class { 'ssh::client': }
    class { 'ssh::server': }
```

It results in a broken sshd_config (and ssh_config as well):
```
[root@centos6 vagrant]# puppet apply test.pp --modulepath=modules/
Notice: Compiled catalog for centos6 in environment production in 0.33 seconds
Error: Could not start Service[ssh]: Execution of '/sbin/service sshd start' returned 255: Starting sshd: /etc/ssh/sshd_config line 8: missing address family.
[FAILED]
Error: /Stage[main]/Ssh::Server/Service[ssh]/ensure: change from stopped to running failed: Could not start Service[ssh]: Execution of '/sbin/service sshd start' returned 255: Starting sshd: /etc/ssh/sshd_config line 8: missing address family.
[FAILED]
Notice: Applied catalog in 0.23 seconds
```

This PR fixes that issue.