### PR TITLE
Implement match rules with a nested hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ Default value:undef,
 
 Default value:undef,
 
+####`match`
+
+Default value: {}
+
+```
+# Example
+ssh::server::match:
+  user:
+    john:
+      AllowTcpForwarding: 'yes'
+  group:
+    sftp:
+      ChrootDirectory:    '%h'
+      ForceCommand:       'internal-sftp'
+      AllowTcpForwarding: 'no'
+```
+
 ####`template`
 
 Default value:ssh/sshd_config.erb',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class ssh::params {
   $use_pam                         = 'yes'
   $use_dns                         = 'yes'
   $x11_forwarding                  = 'no'
+  $match                           = {}
   case $::osfamily {
     'Debian': {
       $subsystem_sftp  = '/usr/lib/openssh/sftp-server'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -36,6 +36,7 @@ class ssh::server (
   $use_dns                        = $::ssh::params::use_dns,
   $use_pam                        = $::ssh::params::use_pam,
   $x11_forwarding                 = $::ssh::params::x11_forwarding,
+  $match                          = $::ssh::params::match
 ) inherits ssh::params {
   validate_re( $permit_tty, 'yes|no' )
 

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -146,3 +146,14 @@ Match User <%= match_user %>
 <% end -%>
 <% end -%>
 <% end -%>
+
+<% if @match.any? -%>
+<% @match.each do |criteria, patterns| -%>
+<% patterns.each do |pattern, config| -%>
+Match <%= criteria %> <%= pattern %>
+<% config.each do |conf, value| -%>
+    <%= conf %> <%= value %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
This PR is to close the other [PR](https://github.com/attachmentgenie/attachmentgenie-ssh/pull/32) that is based on master instead of a branch name.


My last comment :

Hi @attachmentgenie
I have noticed that in a commit, a feature for PermitTTY options in the Match User config has been added.
I don't want to tell you what you should or should not do but please consider that with this commit, EVERY Match config can be handled by the user using simple hashtable array like notation. The number of variable for the ssh::server class would be reduced and would not grow because of more individual Match option.

Regards,