### PR TITLE
Conditionnaly add PermitTTY config if defined

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -37,7 +37,9 @@ class ssh::server (
   $use_pam                        = $::ssh::params::use_pam,
   $x11_forwarding                 = $::ssh::params::x11_forwarding,
 ) inherits ssh::params {
-  validate_re( $permit_tty, 'yes|no' )
+  if $permit_tty {
+    validate_re( $permit_tty, 'yes|no' )
+  }
 
   $match_users = union($password_authentication_users, keys($permit_tty_users))
 

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -119,7 +119,9 @@ AllowUsers <%= @allowed_users.join(" ") %>
 AllowGroups <%= @allowed_groups.join(" ") %>
 <% end -%>
 
+<% if @permit_tty %>
 PermitTTY <%= @permit_tty %>
+<% end -%>
 PermitTunnel <%= @permit_tunnel %>
 GatewayPorts <%= @gateway_ports %>
 PermitUserEnvironment <%= @permit_user_environment %>


### PR DESCRIPTION
PermitTTY does not exists on old sshd_config, (wheezy in our case)

And sshd does not start if there is a problem in the config file... So this fix allow our sshd to start!